### PR TITLE
fix documentation typos

### DIFF
--- a/source/includes/_content_access_management.md
+++ b/source/includes/_content_access_management.md
@@ -40,13 +40,13 @@ If you decline to pass query params - this call will return all access records a
 
 ### HTTP Request
 
-`GET management/v1/repository/{repositorySlug}/access`
+`GET management/v1/repository/{repositoryId}/access`
 
 ### URL Params
 
 | URL Param | Type   | Required  | Description                                    |
 | --------- | ------ | --------- | ---------------------------------------------- |
-| repositorySlug | String | true | The slug of the content repository whose access records you wish to view. |
+| repositoryId | String | true | The ID of the content repository whose access records you wish to view. |
 
 ### Request Query Params
 
@@ -81,7 +81,7 @@ If you decline to pass query params - this call will return all access records a
 
 ### HTTP Request
 
-`GET management/v1/repository/{repositorySlug}/access/item/{contentItemId}`
+`GET management/v1/repository/{repositoryId}/access/item/{contentItemId}`
 
 **Response Codes**:
 
@@ -91,8 +91,8 @@ If you decline to pass query params - this call will return all access records a
 
 | URL Param | Type   | Required | Description                                    |
 | --------- | ------ | -------- | ---------------------------------------------- |
-| repositorySlug | string | true | The slug of the content repository whose access records you wish to view |
-| contentItemId | string | true | The Id of the content item whose access records you wish to view |
+| repositoryId | string | true | The ID of the content repository whose access records you wish to view |
+| contentItemId | string | true | The ID of the content item whose access records you wish to view |
 
 ### Request Query Params
 
@@ -148,7 +148,7 @@ If you decline to pass query params - this call will return all access records a
 
 ### HTTP Request
 
-`POST management/v1/repository/{repositorySlug}/access/item`
+`POST management/v1/repository/{repositoryId}/access/item`
 
 **Response Codes**:
 
@@ -303,8 +303,8 @@ Removing access follows a very similar pattern to querying for them. One importa
 
 ### HTTP Request
 
-`DELETE management/v1/content/{repositorySlug}/{contentItemId}`,
-`DELETE management/v1/content/{repositorySlug}`
+`DELETE management/v1/repository/{repositoryId}/access/item/{contentItemId}`,
+`DELETE management/v1/repository/{repositoryId}/access`
 
 **Response Codes**:
 

--- a/source/includes/_jwt_token.md
+++ b/source/includes/_jwt_token.md
@@ -14,7 +14,7 @@ To create a valid JWT you will need to sign it with your evocalize `jwt_secret`.
 
 ### Variables you provide to Evocalize
 
-You will need you provide us with Login URL's to send a user if the arrive on the site unauthenticated or their JWT token expires. Typically we recommend having both a staging and a production endpoint
+You will need you provide us with Login URL's to send a user if the arrive on the site unauthenticated or their JWT token expires. Typically, we recommend having both a staging and a production endpoint
 when integrating.
 
 ### SSO Endpoints for Evocalize Web App
@@ -26,7 +26,7 @@ This is where you will redirect your users after generating a JWT for them on yo
 
 ## Authentication Flow
 
-> JWT Auth flow psuedo code example
+> JWT Auth flow pseudo code example
 
 ```javascript
 
@@ -45,7 +45,7 @@ const userJwtBlob = {
 const jwt = generateJwt(userJwtBlob, jwtSecret);
 
 // 2. Redirect the user to a new Evocalize SSO endpoint with the JWT
-redirectUser('https://office.your-white-label-domain.com/#/ss?token=' + jwt);
+redirectUser('https://your-white-label-domain.com/#/sso?token=' + jwt);
 
 ```
 


### PR DESCRIPTION
Changes to content access API documentation:
* `repositorySlug` was renamed to `repositoryId` - this was done to make it match the content management API documentation. Could have switch content management documentation to match access docs instead (in other words, go with slug instead of ID), but nowhere else do we use the term "slug" in our docs so I thought it would be better to go with ID.
* fixes incorrect paths

Changes to jwt documentation:
* fixes incorrect path
* removes `office.`
* psuedo -> pseudo