### PR TITLE
EP-897 better callout that duplicate leads can be sent

### DIFF
--- a/source/includes/_webhook_integration.md
+++ b/source/includes/_webhook_integration.md
@@ -2,18 +2,30 @@
 
 ## Client Leads Webhook
 
-Evocalize can notify your organization via webhook any time a new lead is ingested from an upstream platform such as Facebook or Google. Upon notification from the upstream platform that new lead data has been created, we combine that with Evocalize data and your data, and send it to you, allowing you to handle leads in near real-time.
+Evocalize can notify your organization via webhook any time a new lead is ingested from an upstream platform such as
+Facebook or Google. Upon notification from the upstream platform that new lead data has been created, we combine that
+with Evocalize data and your data, and send it to you, allowing you to handle leads in near real-time.
 
 ### Setup
 
-You will need to work with your account manager and supply Evocalize with an endpoint url where you would like to be notified with the payload specified below. Your endpoint url must use SSL (https) and accept a POST. You will need to have a `ClientKeyID` and a `ClientSecret`. These are the same values that you will use to call our API for other operations.
+You will need to work with your account manager and supply Evocalize with an endpoint url where you would like to be
+notified with the payload specified below. Your endpoint url must use SSL (https) and accept a POST. You will need to
+have a `ClientKeyID` and a `ClientSecret`. These are the same values that you will use to call our API for other
+operations.
 
 ### Policies
 
-- Each lead may be delivered more than once. This is rare, but it is possible. The leads[].id is unique to a particular lead and will not change between deliveries if a lead is delivered multiple times.
-- Any response code in the range of 200 - 299 is considered a success, any other response code is considered a failure and we will attempt to redeliver the lead notification.
-- The HTTPS request will time out after 5 seconds. If this happens, delivery is considered a failure and we will attempt to redeliver the lead notification.
-- The time between retry attempts is exponential, with a maximum of 15 minutes between tries. After three hours have elapsed since the first attempt, we will no longer try to deliver the leads. If something has happened causing your platform to stop ingesting leads for more than 3 hours, contact your Evocalize account representative.
+- ℹ️ **Duplicate Leads: If any update sent to your server fails, we will retry several times with decreasing frequency until
+  we get a success. While this helps ensure you receive all of your leads, it can create duplicates on your end so your
+  server should handle deduplication in these cases. All leads have a unique `leads[].id` field you can use for the deduplication
+  process.**
+- Any response code in the range of 200 - 299 is considered a success, any other response code is considered a failure
+  and we will attempt to redeliver the lead notification.
+- The HTTPS request will time out after 5 seconds. If this happens, delivery is considered a failure and we will attempt
+  to redeliver the lead notification.
+- The time between retry attempts is exponential, with a maximum of 15 minutes between tries. After three hours have
+  elapsed since the first attempt, we will no longer try to deliver the leads. If something has happened causing your
+  platform to stop ingesting leads for more than 3 hours, contact your Evocalize account representative.
 
 ### Headers
 
@@ -42,14 +54,18 @@ val toValidate = StringBuilder()
 val expectedSignature = Hashing.sha256().hashString(toValidate, Charsets.UTF_8)
 ```
 
-For extra security, partners may have the need or desire to validate each individual request signature. Validating the request signature provides extra security over relying solely on the `ClientKeyId` because it uses the `ClientSecret` above. The `ClientSecret` is never sent over the wire. The methodology is simple. Join the following values into one string, separated by a newline, then hash them using SHA-256
+For extra security, partners may have the need or desire to validate each individual request signature. Validating the
+request signature provides extra security over relying solely on the `ClientKeyId` because it uses the `ClientSecret`
+above. The `ClientSecret` is never sent over the wire. The methodology is simple. Join the following values into one
+string, separated by a newline, then hash them using SHA-256
 
 - urlPath
 - requestBody
 - X-Evocalize-Timestamp header
 - ClientSecret
 
-Since we require the use of the https protocol for our webhooks, it is up to each partner to choose if they would like to validate the signature.
+Since we require the use of the https protocol for our webhooks, it is up to each partner to choose if they would like
+to validate the signature.
 
 ### Payload
 
@@ -73,7 +89,9 @@ Since we require the use of the https protocol for our webhooks, it is up to eac
         "leadForm": [
           {
             "name": "field_one",
-            "values": ["value one"]
+            "values": [
+              "value one"
+            ]
           }
         ]
       },
@@ -129,7 +147,14 @@ Since we require the use of the https protocol for our webhooks, it is up to eac
           "gclId": "gclId-1652440203604",
           "leadId": "1652440203598"
         },
-        "leadForm": [{ "name": "field_one", "values": ["value one"] }]
+        "leadForm": [
+          {
+            "name": "field_one",
+            "values": [
+              "value one"
+            ]
+          }
+        ]
       },
       "content": [
         [
@@ -182,7 +207,14 @@ Since we require the use of the https protocol for our webhooks, it is up to eac
           "adId": 1652440203722,
           "createdAtEpochSeconds": 1652440203724
         },
-        "leadForm": [{ "name": "field_one", "values": ["value_one"] }]
+        "leadForm": [
+          {
+            "name": "field_one",
+            "values": [
+              "value_one"
+            ]
+          }
+        ]
       },
       "content": [
         [
@@ -220,12 +252,15 @@ Since we require the use of the https protocol for our webhooks, it is up to eac
 }
 ```
 
-Special consideration should be taken not to fail if a new field is present in your data that you did not expect. We will notify you when a field is removed from our specification, but we will not notify you when a field is added to the specification. If a field is removed from the specification, the payloadVersion will increment.
+Special consideration should be taken not to fail if a new field is present in your data that you did not expect. We
+will notify you when a field is removed from our specification, but we will not notify you when a field is added to the
+specification. If a field is removed from the specification, the payloadVersion will increment.
 
-The potential values of leadForm and content depends upon your imported data and program setup. Your account representative can help with this.
+The potential values of leadForm and content depends upon your imported data and program setup. Your account
+representative can help with this.
 
 | Field                                         | Nullable | Type   | Description                                                                |
-| --------------------------------------------- | -------- | ------ | -------------------------------------------------------------------------- |
+|-----------------------------------------------|----------|--------|----------------------------------------------------------------------------|
 | leads                                         | false    | array  | A list of lead data.                                                       |
 | leads[]                                       | false    | object |                                                                            |
 | leads[].id                                    | false    | string | The id of this lead.                                                       |
@@ -255,30 +290,31 @@ The potential values of leadForm and content depends upon your imported data and
 | leads[].order.orderItem                       | false    | object |                                                                            |
 | leads[].order.orderItem.orderItemId           | false    | long   | The order item id associated with the order project.                       |
 
-<sup>\*</sup>If you have values that you need our API to return for this field, please contact your Evocalize account representative.
+<sup>\*</sup>If you have values that you need our API to return for this field, please contact your Evocalize account
+representative.
 
 ### Facebook Lead Data
 
-| Field                                          | Nullable | Type   | Description                                                                                             |
-| ---------------------------------------------- | -------- | ------ | ------------------------------------------------------------------------------------------------------- |
-| leads[].facebook.summary                       | false    | object | Summary data for this Facebook lead.                                                                    |
-| leads[].facebook.summary.leadgenId             | false    | string | Facebook's leadgen_id.                                                                                  |
-| leads[].facebook.summary.pageId                | false    | string | The Facebook page that the ad for this lead is associated with.                                         |
-| leads[].facebook.summary.leadFormId            | false    | string | The Facebook lead form id associated with this lead.                                                    |
-| leads[].facebook.summary.adgroupId             | false    | string | The Facebook adgroup id associated with this lead.                                                      |
-| leads[].facebook.summary.adId                  | false    | string | The Facebook ad id associated with this lead.                                                           |
-| leads[].facebook.summary.retailerItemId        | false    | string | (Dynamic Ads Only) Id of the content (in catalog) that the user clicked on before submitting their lead.|
-| leads[].facebook.summary.createdAtEpochSeconds | false    | long   | The time this lead was created, as a unix timestamp in seconds.                                         |
-| leads[].facebook.leadForm                      | false    | array  | Values that a person filled out on the lead form.                                                       |
-| leads[].facebook.leadForm[]                    | false    | object |                                                                                                         |
-| leads[].facebook.leadForm[].name               | false    | string | The name of the Facebook lead form field.                                                               |
-| leads[].facebook.leadForm[].values             | false    | array  | An array of the values the user filled out.                                                             |
-| leads[].facebook.leadForm[].values[]           | false    | string | Each element is a value that the end user selected or entered. In most cases there is only one element. |
+| Field                                          | Nullable | Type   | Description                                                                                              |
+|------------------------------------------------|----------|--------|----------------------------------------------------------------------------------------------------------|
+| leads[].facebook.summary                       | false    | object | Summary data for this Facebook lead.                                                                     |
+| leads[].facebook.summary.leadgenId             | false    | string | Facebook's leadgen_id.                                                                                   |
+| leads[].facebook.summary.pageId                | false    | string | The Facebook page that the ad for this lead is associated with.                                          |
+| leads[].facebook.summary.leadFormId            | false    | string | The Facebook lead form id associated with this lead.                                                     |
+| leads[].facebook.summary.adgroupId             | false    | string | The Facebook adgroup id associated with this lead.                                                       |
+| leads[].facebook.summary.adId                  | false    | string | The Facebook ad id associated with this lead.                                                            |
+| leads[].facebook.summary.retailerItemId        | false    | string | (Dynamic Ads Only) Id of the content (in catalog) that the user clicked on before submitting their lead. |
+| leads[].facebook.summary.createdAtEpochSeconds | false    | long   | The time this lead was created, as a unix timestamp in seconds.                                          |
+| leads[].facebook.leadForm                      | false    | array  | Values that a person filled out on the lead form.                                                        |
+| leads[].facebook.leadForm[]                    | false    | object |                                                                                                          |
+| leads[].facebook.leadForm[].name               | false    | string | The name of the Facebook lead form field.                                                                |
+| leads[].facebook.leadForm[].values             | false    | array  | An array of the values the user filled out.                                                              |
+| leads[].facebook.leadForm[].values[]           | false    | string | Each element is a value that the end user selected or entered. In most cases there is only one element.  |
 
 ### Google Lead Data
 
 | Field                              | Nullable | Type   | Description                                                                                             |
-| ---------------------------------- | -------- | ------ | ------------------------------------------------------------------------------------------------------- |
+|------------------------------------|----------|--------|---------------------------------------------------------------------------------------------------------|
 | leads[].google.summary             | false    | object | Summary data for this Google lead.                                                                      |
 | leads[].google.summary.campaignId  | false    | string | Google's campaign ID.                                                                                   |
 | leads[].google.summary.formId      | false    | string | The Google lead form ID.                                                                                |
@@ -295,7 +331,7 @@ The potential values of leadForm and content depends upon your imported data and
 ### TikTok Lead Data
 
 | Field                                        | Nullable | Type   | Description                                                                                             |
-| -------------------------------------------- | -------- | ------ | ------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------|----------|--------|---------------------------------------------------------------------------------------------------------|
 | leads[].tikTok.summary                       | false    | object | Summary data for this facebook lead.                                                                    |
 | leads[].tikTok.summary.leadgenId             | false    | string | Facebook's leadgen_id.                                                                                  |
 | leads[].tikTok.summary.pageId                | false    | string | The facebook page that the ad for this lead is associated with.                                         |

--- a/source/includes/_webhook_integration.md
+++ b/source/includes/_webhook_integration.md
@@ -15,10 +15,10 @@ operations.
 
 ### Policies
 
-- ℹ️ **Duplicate Leads: If any update sent to your server fails, we will retry several times with decreasing frequency until
-  we get a success. While this helps ensure you receive all of your leads, it can create duplicates on your end so your
-  server should handle deduplication in these cases. All leads have a unique `leads[].id` field you can use for the deduplication
-  process.**
+- ℹ️ **Duplicate Leads: Each lead may be delivered more than once. For example, if any update sent to your server fails,
+  we will retry several times with decreasing frequency until we get a success. While this helps ensure you receive all
+  of your leads, it can create duplicates on your end so your server should handle deduplication in these cases. All
+  leads have a unique `leads[].id` field you can use for the deduplication process.**
 - Any response code in the range of 200 - 299 is considered a success, any other response code is considered a failure
   and we will attempt to redeliver the lead notification.
 - The HTTPS request will time out after 5 seconds. If this happens, delivery is considered a failure and we will attempt


### PR DESCRIPTION
Swapping out existing duplicate lead verbiage for what was in the EP ticket. Formatted the file too but no actual changes besides the verbiage update. 
https://evocalize.atlassian.net/browse/EP-897

Before
<img width="1052" alt="Screenshot 2024-02-06 at 3 15 26 PM" src="https://github.com/Evocalize/slate/assets/85188438/09300c31-2359-4840-a000-a947d4d6434d">
After (updated)
<img width="1023" alt="Screenshot 2024-02-06 at 3 37 08 PM" src="https://github.com/Evocalize/slate/assets/85188438/c068a976-3540-4c2b-ba70-c37dd860a907">
