### PR TITLE
EP-2292: clarify profile image fields reference user-assigned media assets

### DIFF
--- a/source/includes/_user_and_group_management_api.md
+++ b/source/includes/_user_and_group_management_api.md
@@ -442,7 +442,9 @@ the user's name will be synced to match.
 The image fields within `profileData`, such as `businessLogo` and `profileImageHeadshot`, do not accept image URLs or
 file uploads. They reference media assets that already exist in your organization's Media Library. Import the asset
 first via [Create Or Update Media](#create-or-update-media), then supply the `id` you assigned to it along with its
-`type`. See the [Digital Asset Management API](#digital-asset-management-api) section for more details.
+`type`. The media asset must also be assigned to the same user whose profile you are updating - include a grant with a
+`USER` grantee for that `userId` and the `READ` permission when importing the asset. See the
+[Digital Asset Management API](#digital-asset-management-api) section for more details.
 
 ### HTTP Request
 
@@ -459,7 +461,7 @@ first via [Create Or Update Media](#create-or-update-media), then supply the `id
 | Field       | Required | Type       | Description                                                                                                    |
 |-------------|----------|------------|----------------------------------------------------------------------------------------------------------------|
 | profileType | false    | String     | The profile type to create or update. If omitted, defaults to the user's assigned type or the organization's configured type. |
-| profileData | true     | JSON Object | A key-value map of profile fields. Image fields such as `businessLogo` and `profileImageHeadshot` reference media assets by `id` and `type`. See [Digital Asset Management API](#digital-asset-management-api). |
+| profileData | true     | JSON Object | A key-value map of profile fields. Image fields such as `businessLogo` and `profileImageHeadshot` reference media assets by `id` and `type`, and each asset must be assigned to this user. See [Digital Asset Management API](#digital-asset-management-api). |
 | isActive    | false    | boolean    | Whether the profile is active. Defaults to `true`.                                                             |
 
 **Response Codes**:
@@ -603,8 +605,9 @@ which can be used to track status of the requests as they are processed in our s
 As with [Create Or Update User Profile](#create-or-update-user-profile), the image fields within `profileData`, such as
 `businessLogo` and `profileImageHeadshot`, reference media assets in your organization's Media Library rather than
 image URLs. Import the asset first via [Create Or Update Media](#create-or-update-media), then supply the `id` you
-assigned to it along with its `type`. See the [Digital Asset Management API](#digital-asset-management-api) section for
-more details.
+assigned to it along with its `type`. Each media asset must also be assigned to the same user whose profile it appears
+on - include a grant with a `USER` grantee for that entry's `userId` and the `READ` permission when importing the
+asset. See the [Digital Asset Management API](#digital-asset-management-api) section for more details.
 
 ### HTTP Request
 
@@ -616,7 +619,7 @@ more details.
 |-------------|----------|-------------|----------------------------------------------------------------------------------------------------------------|
 | userId      | true     | String      | The ID of the user whose profile you want to create or update.                                                 |
 | profileType | false    | String      | The profile type to create or update. If omitted, defaults to the user's assigned type or the organization's configured type. |
-| profileData | true     | JSON Object | A key-value map of profile fields. Image fields such as `businessLogo` and `profileImageHeadshot` reference media assets by `id` and `type`. See [Digital Asset Management API](#digital-asset-management-api). |
+| profileData | true     | JSON Object | A key-value map of profile fields. Image fields such as `businessLogo` and `profileImageHeadshot` reference media assets by `id` and `type`, and each asset must be assigned to that entry's user. See [Digital Asset Management API](#digital-asset-management-api). |
 | isActive    | false    | boolean     | Whether the profile is active. Defaults to `true`.                                                             |
 
 **Response Codes**:

--- a/source/includes/_user_and_group_management_api.md
+++ b/source/includes/_user_and_group_management_api.md
@@ -439,6 +439,11 @@ This endpoint allows you to create or update a profile for a user. If the user a
 type, it will be updated. Otherwise, a new profile will be created. If the `profileData` contains a `fullName` field,
 the user's name will be synced to match.
 
+The image fields within `profileData`, such as `businessLogo` and `profileImageHeadshot`, do not accept image URLs or
+file uploads. They reference media assets that already exist in your organization's Media Library. Import the asset
+first via [Create Or Update Media](#create-or-update-media), then supply the `id` you assigned to it along with its
+`type`. See the [Digital Asset Management API](#digital-asset-management-api) section for more details.
+
 ### HTTP Request
 
 `POST management/v1/user/{userId}/profile`
@@ -454,7 +459,7 @@ the user's name will be synced to match.
 | Field       | Required | Type       | Description                                                                                                    |
 |-------------|----------|------------|----------------------------------------------------------------------------------------------------------------|
 | profileType | false    | String     | The profile type to create or update. If omitted, defaults to the user's assigned type or the organization's configured type. |
-| profileData | true     | JSON Object | A key-value map of profile fields.                                                                            |
+| profileData | true     | JSON Object | A key-value map of profile fields. Image fields such as `businessLogo` and `profileImageHeadshot` reference media assets by `id` and `type`. See [Digital Asset Management API](#digital-asset-management-api). |
 | isActive    | false    | boolean    | Whether the profile is active. Defaults to `true`.                                                             |
 
 **Response Codes**:
@@ -595,6 +600,12 @@ This endpoint allows you to pass a JSON Array of User Profile objects for creati
 1000 items at a time. The operation is asynchronous - rather than returning the results, you will receive a `reportId`
 which can be used to track status of the requests as they are processed in our system. Reports are stored for 30 days.
 
+As with [Create Or Update User Profile](#create-or-update-user-profile), the image fields within `profileData`, such as
+`businessLogo` and `profileImageHeadshot`, reference media assets in your organization's Media Library rather than
+image URLs. Import the asset first via [Create Or Update Media](#create-or-update-media), then supply the `id` you
+assigned to it along with its `type`. See the [Digital Asset Management API](#digital-asset-management-api) section for
+more details.
+
 ### HTTP Request
 
 `POST management/v1/user/profiles`
@@ -605,7 +616,7 @@ which can be used to track status of the requests as they are processed in our s
 |-------------|----------|-------------|----------------------------------------------------------------------------------------------------------------|
 | userId      | true     | String      | The ID of the user whose profile you want to create or update.                                                 |
 | profileType | false    | String      | The profile type to create or update. If omitted, defaults to the user's assigned type or the organization's configured type. |
-| profileData | true     | JSON Object | A key-value map of profile fields.                                                                             |
+| profileData | true     | JSON Object | A key-value map of profile fields. Image fields such as `businessLogo` and `profileImageHeadshot` reference media assets by `id` and `type`. See [Digital Asset Management API](#digital-asset-management-api). |
 | isActive    | false    | boolean     | Whether the profile is active. Defaults to `true`.                                                             |
 
 **Response Codes**:


### PR DESCRIPTION
## Summary

Follow-up documentation change to the user profile endpoints (previously added in #64). Clarifies that image fields inside `profileData` — such as `businessLogo` and `profileImageHeadshot` — are **not** image URLs or file uploads. They reference media assets that already exist in the organization's Media Library, and each asset must be assigned to the user whose profile it appears on.

## Changes

`source/includes/_user_and_group_management_api.md`:

- **Create Or Update User Profile** — added a paragraph explaining that image fields reference Media Library assets; callers must import the asset via *Create Or Update Media* first, supply the assigned `id` and its `type`, and grant the asset to the same user whose profile is being updated (a `USER` grantee for that `userId` with the `READ` permission).
- **Batch Create Or Update User Profiles** — added the same clarification, scoped per batch entry and cross-referencing the single-profile endpoint.
- Expanded the `profileData` row in both request-body tables to note the `id`/`type` reference, the per-user assignment requirement, and a link to the Digital Asset Management API section.

## Notes

Documentation only — no behavioral or schema changes. All new cross-references point at existing anchors (`#create-or-update-media`, `#digital-asset-management-api`, `#create-or-update-user-profile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)